### PR TITLE
Some small things, some robustness

### DIFF
--- a/lib/torc.rb
+++ b/lib/torc.rb
@@ -2,18 +2,54 @@ require "torc/version"
 require "binding_of_caller"
 
 module Torc
-  def recurse(*args)
-    return [:recurse, args] if instance_variable_defined? :@caller
-    begin
-      @caller = binding.of_caller(1).eval('__method__')
-      caller_args = [:start, args]
-      loop do
-        caller_args = __send__ @caller, *caller_args.last
-        return caller_args unless caller_args.respond_to? :first
-        return caller_args unless caller_args.first == :recurse
-      end
-    ensure
-      remove_instance_variable :@caller if instance_variable_defined? :@caller
+  def self.extended(obj)
+    obj.__send__ :torc_init
+  end
+
+  def initialize(*args)
+    torc_init
+    super
+  end
+
+  def tail_call(name, *args)
+    if @_torc_state[:loop_stack].empty?
+      recurse name, *args
+    else
+      @_torc_state[:swap_to] = [name, args]
+      @_torc_state[:finished] = false
     end
+  end
+
+  def recurse(*args)
+    name = binding.of_caller(1).eval('__method__')
+    if @_torc_state[:loop_stack].last == name
+      @_torc_state[:finished] = false
+      return args
+    else
+      @_torc_state[:loop_stack].push name
+      begin
+        begin
+          @_torc_state[:finished] = true
+          args = __send__ name, *args
+          if @_torc_state[:swap_to]
+            name, args = @_torc_state[:swap_to]
+            @_torc_state[:swap_to] = nil
+          end
+        end until @_torc_state[:finished]
+        return args
+      ensure
+        @_torc_state[:loop_stack].pop
+      end
+    end
+  end
+
+  private
+
+  def torc_init
+    @_torc_state = {
+      loop_stack: [],
+      swap_to:    nil,
+      finished:   true,
+    }
   end
 end

--- a/lib/torc.rb
+++ b/lib/torc.rb
@@ -2,28 +2,18 @@ require "torc/version"
 require "binding_of_caller"
 
 module Torc
-
-
-  def Torc.included(basename)
-    basename.class_eval do
-      include Torc::InstanceMethods
-    end
-  end
-
-  module InstanceMethods
-    def recurse(*args)
-      return [:recurse, args] if instance_variable_defined? :@caller
-      begin
-        @caller = binding.of_caller(1).eval('__method__')
-        caller_args = [:start, args]
-        loop do
-          caller_args = __send__ @caller, *caller_args.last
-          return caller_args unless caller_args.respond_to? :first
-          return caller_args unless caller_args.first == :recurse
-        end
-      ensure
-        remove_instance_variable :@caller if instance_variable_defined? :@caller
+  def recurse(*args)
+    return [:recurse, args] if instance_variable_defined? :@caller
+    begin
+      @caller = binding.of_caller(1).eval('__method__')
+      caller_args = [:start, args]
+      loop do
+        caller_args = __send__ @caller, *caller_args.last
+        return caller_args unless caller_args.respond_to? :first
+        return caller_args unless caller_args.first == :recurse
       end
+    ensure
+      remove_instance_variable :@caller if instance_variable_defined? :@caller
     end
   end
 end

--- a/lib/torc.rb
+++ b/lib/torc.rb
@@ -2,51 +2,42 @@ require "torc/version"
 require "binding_of_caller"
 
 module Torc
-  def self.extended(obj)
-    obj.__send__ :torc_init
-  end
-
-  def initialize(*args)
-    torc_init
-    super
-  end
-
   def tail_call(name, *args)
-    if @_torc_state[:loop_stack].empty?
+    if _torc_state[:loop_stack].empty?
       recurse name, *args
     else
-      @_torc_state[:swap_to] = [name, args]
-      @_torc_state[:finished] = false
+      _torc_state[:swap_to] = [name, args]
+      _torc_state[:finished] = false
     end
   end
 
   def recurse(*args)
     name = binding.of_caller(1).eval('__method__')
-    if @_torc_state[:loop_stack].last == name
-      @_torc_state[:finished] = false
+    if _torc_state[:loop_stack].last == name
+      _torc_state[:finished] = false
       return args
     else
-      @_torc_state[:loop_stack].push name
+      _torc_state[:loop_stack].push name
       begin
         begin
-          @_torc_state[:finished] = true
+          _torc_state[:finished] = true
           args = __send__ name, *args
-          if @_torc_state[:swap_to]
-            name, args = @_torc_state[:swap_to]
-            @_torc_state[:swap_to] = nil
+          if _torc_state[:swap_to]
+            name, args = _torc_state[:swap_to]
+            _torc_state[:swap_to] = nil
           end
-        end until @_torc_state[:finished]
+        end until _torc_state[:finished]
         return args
       ensure
-        @_torc_state[:loop_stack].pop
+        _torc_state[:loop_stack].pop
       end
     end
   end
 
   private
 
-  def torc_init
-    @_torc_state = {
+  def _torc_state
+    @_torc_state ||= {
       loop_stack: [],
       swap_to:    nil,
       finished:   true,

--- a/spec/spec_harness.rb
+++ b/spec/spec_harness.rb
@@ -1,23 +1,28 @@
-module MethodStack
-  class << self
-    def record_depth
-      #subtract 1 for the current scope
-      @depth = caller.length - 1 if caller.length - 1 > @depth
-    end
+module StackDepth
+  def initialize(*)
+    reset_depth
+    super
+  end
 
-    def max_depth
-      @depth
-    end
+  def record_depth
+    #subtract 1 for the current scope
+    @depth = caller.length - 1 if caller.length - 1 > @depth
+  end
 
-    def reset_depth
-      @depth = 0
-    end
+  def max_depth
+    @depth || 0
+  end
+
+  def reset_depth
+    @depth = 0
   end
 end
 
 class Base
+  include StackDepth
+
   def factorial(acc, n)
-    MethodStack.record_depth
+    record_depth
     return acc if n <= 1
     factorial acc * n, n - 1
   end
@@ -29,10 +34,11 @@ class Base
 end
 
 class Recursed
+  include StackDepth
   include Torc
 
   def factorial(acc, n)
-    MethodStack.record_depth
+    record_depth
     return acc if n <= 1
     recurse acc * n, n - 1
   end

--- a/spec/torc_spec.rb
+++ b/spec/torc_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe Torc do
+RSpec.describe Torc do
   let(:base)     { Base.new }
   let(:recursed) { Recursed.new }
   let(:torced)   { Torced.new }
@@ -19,14 +19,91 @@ describe Torc do
       base.factorial(1, num)
       recursed.factorial(1, num)
 
-      recursed_max_stack_depth = 5
+      recursed_max_stack_depth = 3
       expected_depth = base.max_depth - (num - recursed_max_stack_depth)
       expect(recursed.max_depth).to eql(expected_depth)
     end
 
     it "can solve problems that would normally cause stack overflows" do
       double_stack_size = `ulimit -s`.to_i * 2
-      expect(recursed.simple(double_stack_size)).to eql(0)
+
+      expect { base.simple(double_stack_size) }
+        .to(raise_exception(SystemStackError))
+
+      expect(recursed.simple(double_stack_size)).to eq(0)
     end
+
+    it 'can apply recursion to multiple methods' do
+      multiplier = Class.new {
+        include Torc
+
+        def double(n, acc=0)
+          return acc if n <= 0
+          recurse(n-1, acc+2)
+        end
+
+        def triple(n, acc=0)
+          return acc if n <= 0
+          recurse(n-1, acc+3)
+        end
+      }.new
+
+      expect(multiplier.double(10)).to eq(20)
+
+      expect(multiplier.triple( 9)).to eq(27)
+      expect(multiplier.triple(10)).to eq(30)
+      expect(multiplier.triple(11)).to eq(33)
+    end
+
+    it 'can call one recursive method from another' do
+      actual = Class.new {
+        include Torc
+
+        def cascading_sum(n, acc=0)
+          return acc if n <= 0
+          recurse(n-1, acc+sum(n))
+        end
+
+        def sum(n, acc=0)
+          return acc if n <= 0
+          recurse(n-1, acc+n)
+        end
+      }.new.cascading_sum(3)
+
+      expected = 3+2+1 +
+                   2+1 +
+                     1
+
+      expect(actual).to eq(expected)
+    end
+
+
+    it 'can support recursive methods that call back and forth from each other' do
+      actual = Class.new {
+        include Torc
+        def method1(n, acc=0)
+          return acc if n <= 0
+          tail_call :method2, n-1, acc+n
+        end
+        def method2(n, acc=0)
+          return acc if n <= 0
+          tail_call :method1, n-1, acc+n
+        end
+      }.new.method1(6)
+
+      expect(actual).to eq(6+5+4+3+2+1)
+    end
+
+    it 'can be extended onto an object' do
+      obj = Object.new.extend(Torc)
+      def obj.double(n, acc=0)
+        return acc if n <= 0
+        recurse(n-1, acc+2)
+      end
+      expect(obj.double(5)).to eq(10)
+    end
+
+    it 'is unaffected by overriding initialize'
+    it 'does not affect the superclass initialize'
   end
 end

--- a/spec/torc_spec.rb
+++ b/spec/torc_spec.rb
@@ -7,26 +7,21 @@ describe Torc do
   let(:num)      { rand(100..200) }
 
   it 'has a version number' do
-    expect(Torc::VERSION).not_to be nil
+    expect(Torc::VERSION).to be_a_kind_of String
   end
 
   describe '#recurse' do
     it "doesn't alter the answer of the original method" do
-      MethodStack.reset_depth
       expect(recursed.factorial(1,20)).to eql(base.factorial(1,20))
     end
 
     it "keeps the stack from growing" do
-      MethodStack.reset_depth
       base.factorial(1, num)
-      base_depth = MethodStack.max_depth
-
-      MethodStack.reset_depth
       recursed.factorial(1, num)
-      recursed_depth = MethodStack.max_depth
 
       recursed_max_stack_depth = 5
-      expect(recursed_depth).to eql(base_depth - (num - recursed_max_stack_depth))
+      expected_depth = base.max_depth - (num - recursed_max_stack_depth)
+      expect(recursed.max_depth).to eql(expected_depth)
     end
 
     it "can solve problems that would normally cause stack overflows" do


### PR DESCRIPTION
Try it before merging it, b/c the downside is that it's much slower. This is necessary, with the current approach, to achieve the robustness, eg it now allows one method with tailcall to call into another, and allows two tailcalled methods to recursively call back and forth. This means, though, that it has to check which method called it every time, which is very expensive.

Alternative #1, here is a gist that uses Ruby's builtin tailcall optimization (though the API is barely usable): https://gist.github.com/JoshCheek/2ba8f7ef75421a0e6b56

Alternative #2, you could parse and edit the AST https://gist.github.com/JoshCheek/0cf5e6e14335c52f9695
